### PR TITLE
fix: flatten payload as well as exposes

### DIFF
--- a/Sources/mqtt2prom/Models/PayloadFlattener.swift
+++ b/Sources/mqtt2prom/Models/PayloadFlattener.swift
@@ -1,0 +1,24 @@
+import Foundation
+
+struct PayloadFlattener {
+  /// Flattens a nested dictionary into a single-level dictionary with underscore-separated keys.
+  /// Example: {"overload_protection": {"min_current": 0.5}} becomes {"overload_protection_min_current": 0.5}
+  static func flatten(_ payload: [String: Any], prefix: String = "") -> [String: Any] {
+    var result: [String: Any] = [:]
+
+    for (key, value) in payload {
+      let newKey = prefix.isEmpty ? key : "\(prefix)_\(key)"
+
+      if let nested = value as? [String: Any] {
+        let flattened = flatten(nested, prefix: newKey)
+        for (flatKey, flatValue) in flattened {
+          result[flatKey] = flatValue
+        }
+      } else {
+        result[newKey] = value
+      }
+    }
+
+    return result
+  }
+}

--- a/Sources/mqtt2prom/Services/MetricsManager.swift
+++ b/Sources/mqtt2prom/Services/MetricsManager.swift
@@ -18,8 +18,10 @@ actor MetricsManager {
   ) {
     logger.trace("Processing payload [\(payload)] for device \(deviceInfo.device.friendlyName)")
 
+    let flattenedPayload = PayloadFlattener.flatten(payload)
+
     for expose in deviceInfo.exposes {
-      guard let value = payload[expose.property] else {
+      guard let value = flattenedPayload[expose.property] else {
         logger.warning("No value for property \(expose.property) for device \(deviceInfo.device.friendlyName)")
         continue
       }

--- a/Tests/zmqtt2promTests/zmqtt2promTests.swift
+++ b/Tests/zmqtt2promTests/zmqtt2promTests.swift
@@ -291,6 +291,94 @@ final class zmqtt2promTests: XCTestCase {
     )
   }
 
+  // MARK: - Nested Payload Tests
+
+  func testProcessPayloadWithNestedProperties() async throws {
+    let manager = MetricsManager()
+
+    let device = Device(
+      disabled: false,
+      friendlyName: "Test Device",
+      ieeeAddress: "0x123456789abcdef0",
+      interviewCompleted: true,
+      manufacturer: "TestCorp",
+      modelId: "TEST01",
+      networkAddress: 12345,
+      supported: true,
+      type: "EndDevice",
+      definition: nil
+    )
+
+    // Create exposes that match what ExposeFlattener would produce
+    // for a composite "overload_protection" with nested "min_current"
+    let exposes = [
+      FlattenedExpose(
+        expose: Expose(
+          type: .numeric,
+          property: "min_current",
+          name: "Min current",
+          unit: "A",
+          access: nil,
+          category: nil,
+          description: nil,
+          features: nil,
+          valueOn: nil,
+          valueOff: nil,
+          values: nil,
+          valueMin: nil,
+          valueMax: nil,
+          valueStep: nil
+        ),
+        propertyPath: "overload_protection"
+      ),
+      FlattenedExpose(
+        expose: Expose(
+          type: .numeric,
+          property: "current",
+          name: "Current",
+          unit: "A",
+          access: nil,
+          category: nil,
+          description: nil,
+          features: nil,
+          valueOn: nil,
+          valueOff: nil,
+          values: nil,
+          valueMin: nil,
+          valueMax: nil,
+          valueStep: nil
+        )
+      ),
+    ]
+
+    let deviceInfo = DeviceInfo(device: device, exposes: exposes)
+
+    // This is the actual payload structure from zigbee2mqtt - nested!
+    let payload: [String: Any] = [
+      "current": 0.47,
+      "overload_protection": [
+        "min_current": 0.5,
+        "max_current": 17.0,
+      ] as [String: Any],
+    ]
+
+    await manager.processPayload(payload, for: deviceInfo)
+
+    var buffer = [UInt8]()
+    await manager.registry.emit(into: &buffer)
+    let output = String(decoding: buffer, as: UTF8.self)
+
+    // Both the top-level current and nested overload_protection_min_current should be captured
+    XCTAssertTrue(
+      output.contains("0.47"),
+      "Top-level current should be captured. Output: \(output)"
+    )
+    XCTAssertTrue(
+      output.contains("0.5"),
+      "Nested overload_protection_min_current should be captured. Output: \(output)"
+    )
+  }
+
   // MARK: - MQTT Config Tests
 
   func testMQTTConfig() throws {


### PR DESCRIPTION
I have a device that exposes state like this:

```json
{
  "current": 0.47,
  "energy": 0.1,
  "energy_month": 0.15,
  "energy_today": 0.15,
  "energy_yesterday": 0,
  "linkquality": 176,
  "outlet_control_protect": false,
  "overload_protection": {
    "enable_max_voltage": "ENABLE",
    "enable_min_current": "DISABLE",
    "enable_min_power": "DISABLE",
    "enable_min_voltage": "DISABLE",
    "max_current": 922550.528,
    "max_power": 0,
    "max_voltage": -45088.768,
    "min_current": 0,
    "min_power": 0,
    "min_voltage": 0.049
  },
  "power": 93.28,
  "power_on_behavior": "off",
  "state": "ON",
  "update": {
    "installed_version": 4098,
    "latest_release_notes": null,
    "latest_source": null,
    "latest_version": 4098,
    "state": "idle"
  },
  "voltage": 228.99
}
```

Before this PR, this would result in a bunch of logs like
```
2026-03-05T21:17:44+0100 warning zmqtt2prom.metrics: [zmqtt2prom] No value for property overload_protection_max_current for device Stecker Desk
2026-03-05T21:17:44+0100 warning zmqtt2prom.metrics: [zmqtt2prom] No value for property overload_protection_enable_min_current for device Stecker Desk
2026-03-05T21:17:44+0100 warning zmqtt2prom.metrics: [zmqtt2prom] No value for property overload_protection_min_current for device Stecker Desk
```

because the `MetricsManager` would attempt to find `payload["overload_protection_enable_min_current"]` instead of `payload["overload_protection"]["enable_min_current"]`.

If I'm understanding the code correctly, I don't see how flattened proprety would every work without this fix, but maybe I'm missing something.